### PR TITLE
Remove usage of /_doc in bulk API and docs referencing search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,10 @@ You can query Elasticsearch the `post/3` function:
 
 ```elixir
 # Raw query
-Elasticsearch.post(MyApp.ElasticsearchCluster, "/posts/_doc/_search", '{"query": {"match_all": {}}}')
+Elasticsearch.post(MyApp.ElasticsearchCluster, "/posts/_search", '{"query": {"match_all": {}}}')
 
 # Using a map
-Elasticsearch.post(MyApp.ElasticsearchCluster, "/posts/_doc/_search", %{"query" => %{"match_all" => %{}}})
+Elasticsearch.post(MyApp.ElasticsearchCluster, "/posts/_search", %{"query" => %{"match_all" => %{}}})
 ```
 
 See the official Elasticsearch [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.x/index.html)

--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -136,7 +136,7 @@ defmodule Elasticsearch.Index.Bulk do
   end
 
   defp put_bulk_page(config, index_name, items, request_opts) when is_list(items) do
-    Elasticsearch.put(config, "/#{index_name}/_doc/_bulk", Enum.join(items), request_opts)
+    Elasticsearch.put(config, "/#{index_name}/_bulk", Enum.join(items), request_opts)
   end
 
   defp collect_errors({:ok, %{"errors" => true} = response}, errors, action) do


### PR DESCRIPTION
## What

Remove usage of `/_doc` from bulk API.  Update docs to not reference `_doc` with regard to Search API

## Why

Document mapping types (`/<index>/<mapping_type>/<id>`) were deprecated in ES 7.0 / Opensearch 1.x.  `_doc` was used as a placeholder for a document mapping type for several of the APIs to maintain backwards compatibility with old clients and removed in ES 8.0 (including Opensearch 2.x).

 `_doc` is still used as the path for the [document API](https://opensearch.org/docs/latest/api-reference/document-apis/index/).

## Validation Instructions

Check CI pipe on https://github.com/carsdotcom/cars_platform/pull/25018, which references this branch sha
